### PR TITLE
changed from `:` to `~>` for function return type

### DIFF
--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -300,6 +300,9 @@ private:
         if (remaining_source.starts_with("!=")) {
             emit_token<ExclamationEquals>(tokens, 2);
             return 2;
+        } else if (remaining_source.starts_with("~>")) {
+            emit_token<TildeArrow>(tokens, 2);
+            return 2;
         }
 
         static constexpr char identifier_pattern[] = "([a-zA-Z_][a-zA-Z0-9_]*)";

--- a/src/lexer.hpp
+++ b/src/lexer.hpp
@@ -24,6 +24,7 @@
     x(Colon) \
     x(Comma) \
     x(Arrow) \
+    x(TildeArrow) \
     x(EndOfFile) \
     x(Semicolon) \
     x(Plus) \

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -183,6 +183,8 @@ namespace Parser {
             advance();
             const auto name = consume<Identifier>("expected function name");
             consume<LeftParenthesis>("expected \"(\"");
+
+            // parameter list
             auto parameters = ParameterList{};
             while (not end_of_file() and not current_is<RightParenthesis>()) {
                 const auto parameter_name = consume<Identifier>("expected parameter name");
@@ -196,7 +198,7 @@ namespace Parser {
                 }
             }
             consume<RightParenthesis>("expected \")\"");
-            consume<Colon>("expected \":\"");
+            consume<TildeArrow>("expected \"~>\"");
             auto return_type_definition = data_type();
             auto body = block();
             auto namespace_name = get_namespace_qualifier(m_namespaces_stack);

--- a/std/terminal/cursor.bs
+++ b/std/terminal/cursor.bs
@@ -1,6 +1,6 @@
 namespace std {
 
-    function set_cursor_mode(mode: U32): Nothing {
+    function set_cursor_mode(mode: U32) ~> Nothing {
         bsm {
             copy *R0, R1 // get parameter
             copy R1, *CURSOR_MODE // set mode

--- a/std/terminal/terminal.bs
+++ b/std/terminal/terminal.bs
@@ -1,6 +1,6 @@
 namespace std {
 
-    function put_char(char: Char): Nothing {
+    function put_char(char: Char) ~> Nothing {
         bsm {
             copy *R0, R1 // put the value of char into R1
             copy *CURSOR_POINTER, R2 // get the current cursor pointer value


### PR DESCRIPTION
fixes #23