### PR TITLE
73 only functions explicitly marked `export` should be callable from outside of their namespace

### DIFF
--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -344,6 +344,7 @@ private:
             KEYWORD("goto", Goto)
             KEYWORD("nothing", NothingLiteral)
             KEYWORD("Function", CapitalizedFunction)
+            KEYWORD("export", Export)
             if (identifier_result.view() == "bsm") {
                 return inline_assembly(tokens);
             }

--- a/src/lexer.hpp
+++ b/src/lexer.hpp
@@ -70,7 +70,8 @@
     x(Label) \
     x(Goto) \
     x(NothingLiteral) \
-    x(CapitalizedFunction)
+    x(CapitalizedFunction) \
+    x(Export)
 
 // clang-format on
 

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -413,6 +413,7 @@ namespace Parser {
         Identifier name;
         ParameterList parameters;
         std::unique_ptr<DataType> return_type_definition;
+        std::optional<Export> export_token{};
         const DataType* return_type{ nullptr };
         Statements::Block body;
         FunctionOverload* corresponding_symbol{ nullptr };
@@ -421,6 +422,10 @@ namespace Parser {
         std::vector<Statements::LabelDefinition*> contained_labels{};
         std::optional<usize> occupied_stack_space{};  // total size of the needed stack space (in bytes)
         std::optional<usize> parameters_stack_space{};// size of all parameters (in bytes)
+
+        [[nodiscard]] bool is_exported() const {
+            return export_token.has_value();
+        }
     };
 
     struct ImportStatement {

--- a/src/scope_generator.cpp
+++ b/src/scope_generator.cpp
@@ -25,14 +25,10 @@ namespace ScopeGenerator {
         // do not know the function signature), but the function can only be a valid choice
         // if it is within the correct namespace
 
-        fmt::print(stderr, "lookup for {}\n", Error::token_location(name.name_tokens.back()).view());
-
         auto remaining_namespaces = namespace_qualifier.empty() ? 0 : count(namespace_qualifier, ':') / 2;
         const auto was_qualified_name = (name.name_tokens.size() > 1);
         auto possible_overloads = std::vector<const FunctionOverload*>{};
         while (true) {
-            fmt::print(stderr, "searching in namespace {}\n", namespace_qualifier);
-
             // Function definitions are only allowed in the global scope. That means
             // that we must be at the top of the scope stack right now.
             for (const auto& overload : function.overloads) {
@@ -45,17 +41,9 @@ namespace ScopeGenerator {
                     // if the namespace the name expression occurred in is different from the namespace
                     // in which we found the function overload, then the lookup is only valid if the function
                     // has been exported
-                    fmt::print(
-                            stderr, "{}:, surrounding namespace: {}, namespace qualifier: {}, is exported: {}\n",
-                            overload.definition->name.location.view(), name.surrounding_scope->surrounding_namespace,
-                            namespace_qualifier, overload.definition->export_token.has_value()
-                    );
                     if (name.surrounding_scope->surrounding_namespace.starts_with(namespace_qualifier) or
                         overload.definition->is_exported()) {
-                        fmt::print(stderr, "\t=> adding overload\n");
                         possible_overloads.push_back(&overload);
-                    } else {
-                        fmt::print(stderr, "\t=> not adding overload\n");
                     }
                 }
             }

--- a/src/scope_generator.cpp
+++ b/src/scope_generator.cpp
@@ -24,17 +24,39 @@ namespace ScopeGenerator {
         // We *did* find a function symbol with the correct function name (even though we
         // do not know the function signature), but the function can only be a valid choice
         // if it is within the correct namespace
+
+        fmt::print(stderr, "lookup for {}\n", Error::token_location(name.name_tokens.back()).view());
+
         auto remaining_namespaces = namespace_qualifier.empty() ? 0 : count(namespace_qualifier, ':') / 2;
         const auto was_qualified_name = (name.name_tokens.size() > 1);
         auto possible_overloads = std::vector<const FunctionOverload*>{};
         while (true) {
+            fmt::print(stderr, "searching in namespace {}\n", namespace_qualifier);
+
             // Function definitions are only allowed in the global scope. That means
             // that we must be at the top of the scope stack right now.
             for (const auto& overload : function.overloads) {
                 if (overload.namespace_name == namespace_qualifier) {
+                    // we found a possible overload!
+
                     // we cannot determine the return type of the function here because
-                    // we cannot do overload resolution as of now
-                    possible_overloads.push_back(&overload);
+                    // we cannot do type-based overload resolution as of now
+
+                    // if the namespace the name expression occurred in is different from the namespace
+                    // in which we found the function overload, then the lookup is only valid if the function
+                    // has been exported
+                    fmt::print(
+                            stderr, "{}:, surrounding namespace: {}, namespace qualifier: {}, is exported: {}\n",
+                            overload.definition->name.location.view(), name.surrounding_scope->surrounding_namespace,
+                            namespace_qualifier, overload.definition->export_token.has_value()
+                    );
+                    if (name.surrounding_scope->surrounding_namespace.starts_with(namespace_qualifier) or
+                        overload.definition->is_exported()) {
+                        fmt::print(stderr, "\t=> adding overload\n");
+                        possible_overloads.push_back(&overload);
+                    } else {
+                        fmt::print(stderr, "\t=> not adding overload\n");
+                    }
                 }
             }
 
@@ -67,10 +89,15 @@ namespace ScopeGenerator {
             const auto global_name_qualifier = get_absolute_namespace_qualifier(name);
             for (const auto& overload : function.overloads) {
                 if (overload.namespace_name == global_name_qualifier) {
+                    // we found a possible overload!
+
                     // we cannot determine the return type of the function here because
-                    // we cannot do overload resolution as of now
+                    // we cannot do type-based overload resolution as of now
                     if (is_global_lookup_fallback) {
-                        possible_overloads.push_back(&overload);
+                        // during fall-back, only exported functions are valid
+                        if (overload.definition->is_exported()) {
+                            possible_overloads.push_back(&overload);
+                        }
                     } else if (not inside_global_namespace) {
                         Error::warning(
                                 name.name_tokens.back(),
@@ -417,6 +444,13 @@ namespace ScopeGenerator {
         void operator()(std::unique_ptr<Parser::FunctionDefinition>& function_definition) {
             using namespace std::string_literals;
             using std::ranges::find_if;
+
+            if (function_definition->export_token.has_value() and function_definition->namespace_name == "::") {
+                Error::error(
+                        *(function_definition->export_token),
+                        "exporting functions from the global namespace is not allowed"
+                );
+            }
 
             auto identifier = function_definition->name.location.view();
             auto find_iterator = find_if(*global_scope, [&](const auto& pair) { return pair.first == identifier; });

--- a/std/assert.bs
+++ b/std/assert.bs
@@ -1,13 +1,13 @@
  namespace std {
 
-    function assert(condition: Bool) ~> Nothing {
+    export function assert(condition: Bool) ~> Nothing {
         bsm {
             copy *R0, R1
             assert R1, 1
         }
     }
 
-    function assert_equals(lhs: U32, rhs: U32) ~> Nothing {
+    export function assert_equals(lhs: U32, rhs: U32) ~> Nothing {
         bsm {
             copy *R0, R2
             add R0, 4, R1
@@ -16,7 +16,7 @@
         }
     }
 
-    function assert_equals(lhs: Char, rhs: Char) ~> Nothing {
+    export function assert_equals(lhs: Char, rhs: Char) ~> Nothing {
         bsm {
             copy *R0, R2
             add R0, 4, R1
@@ -25,7 +25,7 @@
         }
     }
 
-    function assert_equals(lhs: Bool, rhs: Bool) ~> Nothing {
+    export function assert_equals(lhs: Bool, rhs: Bool) ~> Nothing {
         bsm {
             copy *R0, R2
             add R0, 4, R1
@@ -34,6 +34,6 @@
         }
     }
 
-    function assert_equals(lhs: Nothing, rhs: Nothing) ~> Nothing { }
+    export function assert_equals(lhs: Nothing, rhs: Nothing) ~> Nothing { }
 
  }

--- a/std/terminal/cursor.bs
+++ b/std/terminal/cursor.bs
@@ -1,6 +1,6 @@
 namespace std {
 
-    function set_cursor_mode(mode: U32) ~> Nothing {
+    export function set_cursor_mode(mode: U32) ~> Nothing {
         bsm {
             copy *R0, R1 // get parameter
             copy R1, *CURSOR_MODE // set mode

--- a/std/terminal/terminal.bs
+++ b/std/terminal/terminal.bs
@@ -1,6 +1,6 @@
 namespace std {
 
-    function put_char(char: Char) ~> Nothing {
+    export function put_char(char: Char) ~> Nothing {
         bsm {
             copy *R0, R1 // put the value of char into R1
             copy *CURSOR_POINTER, R2 // get the current cursor pointer value
@@ -30,7 +30,7 @@ namespace std {
         return result;
     }
 
-    function print(n: mutable U32) ~> Nothing {
+    export function print(n: mutable U32) ~> Nothing {
         let factor: mutable U32 = 1000000000; // highest power of 10 representable as a U32
         let started_output: mutable Bool = false;
         while factor > 0 {


### PR DESCRIPTION
fixes #73 