### PR TITLE
implemented a first peephole optimization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ add_executable(Seatbelt
         src/return_type_checker.cpp
         src/mutability.hpp
         src/bssembly.hpp
-        src/overloaded.hpp)
+        src/overloaded.hpp src/bssembly_optimizer.hpp)
 
 target_link_libraries(Seatbelt fmt ctre Arguably)
 

--- a/src/bssembly.hpp
+++ b/src/bssembly.hpp
@@ -66,6 +66,8 @@ namespace Bssembler {
 #undef x
 
     struct DynamicRegister {
+        [[nodiscard]] bool operator==(const DynamicRegister& other) const = default;
+
         u8 number;
     };
 
@@ -107,10 +109,14 @@ namespace Bssembler {
 
         Immediate(std::string_view value) : value{ std::string{ value } } { }
 
+        [[nodiscard]] bool operator==(const Immediate& other) const = default;
+
         std::variant<std::string, usize> value;
     };
 
     struct Pointer {
+        [[nodiscard]] bool operator==(const Pointer& other) const = default;
+
         Register register_;
     };
 
@@ -180,6 +186,14 @@ namespace Bssembler {
     };
 
     class Bssembly {
+    private:
+        using InstructionVariant = std::variant<NewLine, Comment, Instruction, Label, InlineBssembly>;
+        using InstructionVector = std::vector<InstructionVariant>;
+
+    public:
+        using iterator = InstructionVector::iterator;
+        using const_iterator = InstructionVector::const_iterator;
+
     public:
         Bssembly() = default;
 
@@ -227,8 +241,45 @@ namespace Bssembler {
             return *this;
         }
 
-    private:
-        using InstructionVector = std::vector<std::variant<NewLine, Comment, Instruction, Label, InlineBssembly>>;
+        [[nodiscard]] usize size() const {
+            return m_instructions.size();
+        }
+
+        [[nodiscard]] iterator begin() {
+            return m_instructions.begin();
+        }
+
+        [[nodiscard]] const_iterator begin() const {
+            return m_instructions.begin();
+        }
+
+        [[nodiscard]] iterator end() {
+            return m_instructions.begin();
+        }
+
+        [[nodiscard]] const_iterator end() const {
+            return m_instructions.begin();
+        }
+
+        [[nodiscard]] InstructionVariant& operator[](usize index) {
+            return m_instructions[index];
+        }
+
+        [[nodiscard]] const InstructionVariant& operator[](usize index) const {
+            return m_instructions[index];
+        }
+
+        void replace(usize from, usize to, std::initializer_list<InstructionVariant> replacement) {
+            m_instructions.erase(
+                    m_instructions.begin() + static_cast<decltype(m_instructions)::difference_type>(from),
+                    m_instructions.begin() + static_cast<decltype(m_instructions)::difference_type>(to)
+            );
+            auto position = static_cast<decltype(m_instructions)::difference_type>(from);
+            for (const auto& instruction : replacement) {
+                m_instructions.insert(m_instructions.begin() + position, instruction);
+                ++position;
+            }
+        }
 
     private:
         explicit Bssembly(InstructionVector instruction) : m_instructions{ std::move(instruction) } { }

--- a/src/bssembly_optimizer.hpp
+++ b/src/bssembly_optimizer.hpp
@@ -1,0 +1,47 @@
+//
+// Created by coder2k on 28.08.2022.
+//
+
+#pragma once
+
+#include "bssembly.hpp"
+#include <algorithm>
+#include <array>
+#include <fmt/core.h>
+#include <ranges>
+
+inline void optimize(Bssembler::Bssembly& bssembly) {
+    using enum Bssembler::Mnemonic;
+    using namespace Bssembler;
+
+    static constexpr usize window_size = 3;
+    for (usize i = 0; i < bssembly.size() - (window_size - 1); ++i) {
+        auto instructions = std::array<Bssembler::Instruction*, window_size>{};
+        bool all_are_instructions = true;
+        for (usize j = 0; j < window_size; ++j) {
+            instructions[j] = std::get_if<Bssembler::Instruction>(&bssembly[i + j]);
+            if (instructions[j] == nullptr) {
+                all_are_instructions = false;
+                break;
+            }
+        }
+        if (not all_are_instructions) {
+            continue;
+        }
+
+        if (instructions[0]->mnemonic == COPY and instructions[1]->mnemonic == PUSH and
+            instructions[2]->mnemonic == POP) {
+            auto copy_target = instructions[0]->arguments.back();
+            auto push_source = instructions[1]->arguments.front();
+            if (copy_target == push_source) {
+                bssembly.replace(
+                        i, i + 3,
+                        {
+                                Instruction{
+                                            COPY, { instructions[0]->arguments.front(), instructions[2]->arguments.front() }}
+                }
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
This first optimization replaced instructions like the following:
```
COPY 1, R1
PUSH R1
POP R2
```
with
```
COPY 1, R2
```

The newly added `--verbose` flag makes the compiler show the percentage of instructions saved by this optimiziation.